### PR TITLE
test that thing is a map before checking :__struct__

### DIFF
--- a/lib/pundit.ex
+++ b/lib/pundit.ex
@@ -57,7 +57,7 @@ defmodule Pundit do
 
         defmodule Policy do
           use Pundit.DefaultPolicy
-          
+
           def scope(query, user) do
             from post in query,
               where: post.author_id == ^user.id
@@ -102,7 +102,7 @@ defmodule Pundit do
   Returns true only if the user should be allowed to see a form to create a new thing.
 
   See [the page on Phoenix controllers](https://hexdocs.pm/phoenix/controllers.html#actions) for more details on the
-  purpose of this action. 
+  purpose of this action.
   """
   @spec new?(thing :: struct() | module(), user :: term()) :: boolean()
   def new?(thing, user) do
@@ -121,7 +121,7 @@ defmodule Pundit do
   Returns true only if the user should be allowed to see a form for updating the thing.
 
   See [the page on Phoenix controllers](https://hexdocs.pm/phoenix/controllers.html#actions) for more details on the
-  purpose of this action. 
+  purpose of this action.
   """
   @spec edit?(thing :: struct() | module(), user :: term()) :: boolean()
   def edit?(thing, user) do
@@ -237,7 +237,7 @@ defmodule Pundit do
       is_atom(thing) and Kernel.function_exported?(thing, :__info__, 1) ->
         thing
 
-      Map.has_key?(thing, :__struct__) ->
+      is_map(thing) and Map.has_key?(thing, :__struct__) ->
         thing.__struct__
 
       true ->

--- a/test/pundit_test.exs
+++ b/test/pundit_test.exs
@@ -34,6 +34,12 @@ defmodule PunditTest do
       refute Pundit.delete?(thing, %{})
     end
 
+    test "providing nil should ArgumentError" do
+      assert_raise ArgumentError, fn ->
+        refute Pundit.show?(nil, %{})
+      end
+    end
+
     test "calling authorize! raises errors when appropriate" do
       assert_raise(NotAuthorizedError, fn ->
         Pundit.authorize!(ReadableThing, %{}, :edit?)


### PR DESCRIPTION
This PR ensures that passing something other than a struct or module raises an `ArgumentError` not a `BadMapError`.