### PR TITLE
Ensure module compiled within do_scope/2

### DIFF
--- a/lib/pundit.ex
+++ b/lib/pundit.ex
@@ -225,10 +225,12 @@ defmodule Pundit do
   end
 
   defp do_scope(module, query, user) do
-    if Kernel.function_exported?(module, :scope, 2) do
+    with {:module, _module} <- Code.ensure_compiled(module),
+         true <- Kernel.function_exported?(module, :scope, 2) do
       module.scope(query, user)
     else
-      raise NotDefinedError, message: "Function scope/2 not defined on #{module}"
+      _ ->
+        raise NotDefinedError, message: "Function scope/2 not defined on #{module}"
     end
   end
 


### PR DESCRIPTION
We've been noticing an error for a while now that seems to fix itself after a few restarts of our application: `mix phx.server`. 

` ** (Pundit.NotDefinedError) Function scope/2 not defined on Elixir.`

Finally decided to take a closer look and it seems the same technique of using `Code.ensure_compiled` within the `can?` function also works for the `do_scope` function.  