### PR TITLE
Fix module detection during code reload

### DIFF
--- a/lib/pundit.ex
+++ b/lib/pundit.ex
@@ -236,7 +236,7 @@ defmodule Pundit do
 
   defp get_module(thing) do
     cond do
-      is_atom(thing) and Kernel.function_exported?(thing, :__info__, 1) ->
+      is_atom(thing) and match?({:module, _}, Code.ensure_loaded(thing)) ->
         thing
 
       is_map(thing) and Map.has_key?(thing, :__struct__) ->


### PR DESCRIPTION
Kernel.function_exported?(thing, :__info__, 1)` returns `false` during Phoenix code reload when the module hasn't been loaded yet, causing `ArgumentError: The first parameter should be a module or a struct`.

This only affects calls using a module atom like `Pundit.authorize!(Post, user, :index?)`. Calls using a struct like `Pundit.authorize!(%Post{}, user, :index?)` work fine because they match the second condition in `get_module/1`.

Using `Code.ensure_loaded/1` properly loads the module first before checking if it's valid.

**Stack trace:**

```
[18:34:09.405 info] Sent 500 in 14ms
[18:34:09.407 error] #PID<0.874.0> running Phoenix.Endpoint.SyncCodeReloadPlug (connection #PID<0.823.0>, stream id 4) terminated
Server: localhost:3000 (http)
Request: GET /posts
** (exit) an exception was raised:
    ** (ArgumentError) The first parameter should be a module or a struct
        (pundit 1.1.0) lib/pundit.ex:246: Pundit.get_module/1
        (pundit 1.1.0) lib/pundit.ex:183: Pundit.can?/3
        (pundit 1.1.0) lib/pundit.ex:161: Pundit.authorize/3
        (pundit 1.1.0) lib/pundit.ex:144: Pundit.authorize!/3
        (my_app 0.1.0) lib/my_app_web/live/posts/index.ex:12: MyAppWeb.Live.Posts.Index.mount/3
        (phoenix_live_view 0.20.17) lib/phoenix_live_view/utils.ex:343: anonymous fn/6 in Phoenix.LiveView.Utils.maybe_call_live_view_mount!/5
        (telemetry 0.4.3) deps/telemetry/src/telemetry.erl:272: :telemetry.span/3
        (phoenix_live_view 0.20.17) lib/phoenix_live_view/static.ex:281: Phoenix.LiveView.Static.call_mount_and_handle_params!/5
        (phoenix_live_view 0.20.17) lib/phoenix_live_view/static.ex:116: Phoenix.LiveView.Static.render/3
        (phoenix_live_view 0.20.17) lib/phoenix_live_view/controller.ex:39: Phoenix.LiveView.Controller.live_render/3
        (phoenix 1.7.21) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5
        (my_app 0.1.0) lib/my_app_web/endpoint.ex:1: MyAppWeb.Endpoint.plug_builder_call/2
        (phoenix 1.7.21) lib/phoenix/endpoint/sync_code_reload_plug.ex:22: Phoenix.Endpoint.SyncCodeReloadPlug.do_call/4
        (plug_cowboy 2.7.4) lib/plug/cowboy/handler.ex:11: Plug.Cowboy.Handler.init/2
        (cowboy 2.13.0) deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
```

**Root cause:**

When Phoenix code reloader runs, it purges changed modules before recompiling. If a request arrives during this window, `Kernel.function_exported?/3` returns `false` for valid module atoms because it only checks if the module is *currently loaded*, not if it *exists*.

`Code.ensure_loaded/1` fixes this by forcing the module to load before checking, eliminating the race condition.