### PR TITLE
Minor cleanup

### DIFF
--- a/lib/pundit.ex
+++ b/lib/pundit.ex
@@ -139,7 +139,7 @@ defmodule Pundit do
   @doc """
   Raise a `Pundit.NotAuthorizedError` exception unless the user can perform the action on the thing.
   """
-  @spec authorize!(thing :: struct() | module(), user :: term(), action :: atom()) :: boolean()
+  @spec authorize!(thing :: struct() | module(), user :: term(), action :: atom()) :: true
   def authorize!(thing, user, action) do
     case authorize(thing, user, action) do
       {:ok} ->
@@ -166,7 +166,7 @@ defmodule Pundit do
   end
 
   @doc """
-  Determine if a use can perform an action on a given thing.
+  Determine if a user can perform an action on a given thing.
 
   This will attempt to call a function with the same name as the action on the policy
   module of the given thing.  For instance:
@@ -186,7 +186,7 @@ defmodule Pundit do
          true <- Kernel.function_exported?(module, action, 2) do
       apply(module, action, [thing, user])
     else
-      _ -> raise NotDefinedError, message: "#{module}.#{action} is not defined."
+      _ -> raise NotDefinedError, message: "#{module}.#{action}/2 is not defined."
     end
   end
 
@@ -230,7 +230,7 @@ defmodule Pundit do
       module.scope(query, user)
     else
       _ ->
-        raise NotDefinedError, message: "Function scope/2 not defined on #{module}"
+        raise NotDefinedError, message: "#{module}.scope/2 is not defined."
     end
   end
 

--- a/lib/pundit/default_policy.ex
+++ b/lib/pundit/default_policy.ex
@@ -4,7 +4,7 @@ defmodule Pundit.DefaultPolicy do
 
   All of the functions here are named for actions in a [Phoenix controller](https://hexdocs.pm/phoenix/controllers.html#actions).
 
-  If you `use` this module, then default implementations will be added in your module that all 
+  If you `use` this module, then default implementations will be added in your module that all
   return `false` by default (default safe, nothing is permitted).  All are overrideable.
   """
 
@@ -27,7 +27,7 @@ defmodule Pundit.DefaultPolicy do
   Returns true only if the user should be allowed to see a form to create a new thing.
 
   See [the page on Phoenix controllers](https://hexdocs.pm/phoenix/controllers.html#actions) for more details on the
-  purpose of this action. 
+  purpose of this action.
   """
   @callback new?(thing :: struct() | module(), user :: term()) :: boolean()
 
@@ -40,7 +40,7 @@ defmodule Pundit.DefaultPolicy do
   Returns true only if the user should be allowed to see a form for updating the thing.
 
   See [the page on Phoenix controllers](https://hexdocs.pm/phoenix/controllers.html#actions) for more details on the
-  purpose of this action. 
+  purpose of this action.
   """
   @callback edit?(thing :: struct() | module(), user :: term()) :: boolean()
 


### PR DESCRIPTION
- Tighten `authorize!/3` spec from `boolean()` to `true` - it only ever returns `true` or raises.
- Unify `NotDefinedError` messages so `can?/3` and `scope/2` use the same `"Module.fun/2 is not defined."` format.
- Fix a "use" → "user" typo in the `can?/3` docs and trim trailing whitespace in `Pundit.DefaultPolicy`.